### PR TITLE
feat(reading): open in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ nmap g/   <plug>(himalaya-set-list-envelopes-query)
 | Copy the email                 | `gC`    |
 | Move the email                 | `gM`    |
 | Delete the email               | `gD`    |
+| Open the mail in the browser   | `go`    |
 
 Keybinds can be customized:
 
@@ -183,6 +184,7 @@ nmap ga <plug>(himalaya-email-download-attachments)
 nmap gC <plug>(himalaya-email-copy)
 nmap gM <plug>(himalaya-email-move)
 nmap gD <plug>(himalaya-email-delete)
+nmap go <plug>(himalaya-email-open-browser)
 ```
 
 ### Message writing

--- a/autoload/himalaya/domain/email.vim
+++ b/autoload/himalaya/domain/email.vim
@@ -317,6 +317,17 @@ function! himalaya#domain#email#flag_remove() abort range
   \})
 endfunction
 
+function! himalaya#domain#email#open_browser() abort
+  let account = himalaya#domain#account#current()
+  let folder = himalaya#domain#folder#current()
+  call himalaya#request#plain({
+  \ 'cmd': 'message export --account %s --folder %s --open %s',
+  \ 'args': [shellescape(account), shellescape(folder), s:id],
+  \ 'msg': 'Opening message in the browser',
+  \ 'on_data': {data -> himalaya#log#info(data)},
+  \})
+endfunction
+
 function! s:bufwidth() abort " https://newbedev.com/get-usable-window-width-in-vim-script
   let width = winwidth(0)
   let numberwidth = max([&numberwidth, strlen(line('$'))+1])

--- a/ftplugin/himalaya-email-reading.vim
+++ b/ftplugin/himalaya-email-reading.vim
@@ -14,4 +14,5 @@ call himalaya#keybinds#define([
   \['n', 'gC', 'email#select_folder_then_copy'],
   \['n', 'gM', 'email#select_folder_then_move'],
   \['n', 'gD', 'email#delete'                 ],
+  \['n', 'go', 'email#open_browser'           ],
 \])


### PR DESCRIPTION
Add `open_browser` function to export and open the current email in the default browser via Himalaya CLI (`message export --open`).

Introduce `<Plug>(himalaya-email-open-browser)` plus default normal-mode mapping `go` in email reading buffers.