### PR TITLE
fix: handle pipe characters in email listing syntax highlighting

### DIFF
--- a/syntax/himalaya-email-listing.vim
+++ b/syntax/himalaya-email-listing.vim
@@ -2,20 +2,57 @@ if exists('b:current_syntax')
   finish
 endif
 
-syntax match HimalayaSeparator /|/
-syntax match HimalayaId        /^|.\{-}/                          contains=HimalayaSeparator
-syntax match HimalayaFlags     /^|.\{-}|.\{-}/                    contains=HimalayaId,HimalayaSeparator
-syntax match HimalayaSubject   /^|.\{-}|.\{-}|.\{-}/              contains=HimalayaId,HimalayaFlags,HimalayaSeparator
-syntax match HimalayaSender    /^|.\{-}|.\{-}|.\{-}|.\{-}/        contains=HimalayaId,HimalayaFlags,HimalayaSubject,HimalayaSeparator
-syntax match HimalayaDate      /^|.\{-}|.\{-}|.\{-}|.\{-}|.\{-}|/ contains=HimalayaId,HimalayaFlags,HimalayaSubject,HimalayaSender,HimalayaSeparator
-syntax match HimalayaHead      /.*\%1l/                           contains=HimalayaSeparator
-syntax match HimalayaUnseen    /^|.\{-}|.*\*.*$/                  contains=HimalayaSeparator
+" Always highlight pipe separators, even inside column matches
+syntax match HimalayaSeparator /|/ containedin=ALL
 
-" FIXME: Find a way to set the line bold AND to keep the style of each
-" columns.
-" highlight HimalayaUnseen term=bold cterm=bold gui=bold
-
+" Header row (line 1)
+syntax match HimalayaHead /\%1l.*/ contains=HimalayaSeparator
 highlight HimalayaHead term=bold cterm=bold gui=bold
+
+" Table rule row (line 2)
+syntax match HimalayaRule /\%2l.*/ contains=HimalayaSeparator
+highlight default link HimalayaRule WinSeparator
+
+" Derive column boundaries from header pipes
+let s:header = getline(1)
+let s:cols = []
+let s:idx = 0
+
+while 1
+  let s:idx = match(s:header, '|', s:idx)
+  if s:idx == -1
+    break
+  endif
+  call add(s:cols, s:idx + 1)
+  let s:idx += 1
+endwhile
+
+" Data rows start at line 3
+let s:lstart = 3
+
+if len(s:cols) >= 6
+
+  execute 'syntax match HimalayaId /\%>' . (s:lstart - 1) . 'l'
+        \ . '\%>' . s:cols[0] . 'c'
+        \ . '[^|]*/'
+
+  execute 'syntax match HimalayaFlags /\%>' . (s:lstart - 1) . 'l'
+        \ . '\%>' . s:cols[1] . 'c'
+        \ . '[^|]*/'
+
+  execute 'syntax match HimalayaSubject /\%>' . (s:lstart - 1) . 'l'
+        \ . '\%>' . s:cols[2] . 'c'
+        \ . '[^|]*/'
+
+  execute 'syntax match HimalayaSender /\%>' . (s:lstart - 1) . 'l'
+        \ . '\%>' . s:cols[3] . 'c'
+        \ . '[^|]*/'
+
+  execute 'syntax match HimalayaDate /\%>' . (s:lstart - 1) . 'l'
+        \ . '\%>' . s:cols[4] . 'c'
+        \ . '[^|]*/'
+
+endif
 
 highlight default link HimalayaSeparator VertSplit
 highlight default link HimalayaId        Identifier


### PR DESCRIPTION
Fixes #30 

Now:
<img width="1909" height="104" alt="image" src="https://github.com/user-attachments/assets/4990e1ab-218e-449f-844c-17a0c74891d0" />
<img width="1920" height="115" alt="image" src="https://github.com/user-attachments/assets/05f93465-8e50-4209-8bef-9ef7cd841377" />


Uses header to parse the length of columns and uses that to highlight the table body.

This takes into account the presense of unicode characters as well.