### PR TITLE
fix(neovim): check job exit code

### DIFF
--- a/autoload/himalaya/job/neovim.vim
+++ b/autoload/himalaya/job/neovim.vim
@@ -9,7 +9,7 @@ function! himalaya#job#neovim#start(cmd, on_data) abort
   let job = jobstart(cmd[0], {
   \ 'on_stdout': {_, lines -> s:on_stdout(lines)},
   \ 'on_stderr': {_, lines -> s:on_stderr(lines)},
-  \ 'on_exit': {-> s:on_exit(a:on_data)},
+  \ 'on_exit': {_, exit_code -> s:on_exit(exit_code, a:on_data)},
   \})
 
   if len(cmd) > 1
@@ -26,16 +26,22 @@ function! s:on_stderr(lines) abort
   let s:stderr += s:compact_lines(a:lines)
 endfunction
 
-function! s:on_exit(callback) abort
+function! s:on_exit(exit_code, callback) abort
+  if a:exit_code != 0
+    call s:log_error()
+  endif
+
+  call a:callback(s:stdout)
+endfunction
+
+function! s:log_error() abort
   if !empty(s:stderr)
     for line in s:stderr
       call himalaya#log#err(line)
     endfor
-    redraw
-    throw 'CLI error, see :messages for more information'
   endif
-  echom s:stdout
-  call a:callback(s:stdout)
+  redraw
+  throw 'CLI error, see :messages for more information'
 endfunction
 
 function! s:compact_lines(lines) abort


### PR DESCRIPTION
## Summary

This fixes an issue I hit when downloading attachments from an iCloud email.

The attachments were downloaded correctly by the Himalaya CLI, but `himalaya-vim` still showed:

```text
CLI error, see :messages for more information
```
  
The reason was that Himalaya printed non-fatal IMAP parser warnings to stderr while still exiting successfully:
```text
WARN imap_codec::response: Rectified missing `text` to "..."
```

himalaya-vim was treating any stderr output as a failed command. That is too strict for Himalaya, because stderr may contain diagnostics or warnings even when the command succeeds.

This change makes the Neovim job handler use the process exit code to decide whether the command failed. Successful commands no longer fail just because they wrote warnings to stderr. Commands with a nonzero exit code still report an error as before.

## Verification

- Reproduced the issue while downloading iCloud attachments.
- Confirmed the same Himalaya CLI command downloaded the attachments and exited successfully.
- Tested a Neovim job that writes to both stdout and stderr with exit code 0; the callback ran successfully.
- Tested a Neovim job that writes to stderr and exits nonzero; the plugin still reported a CLI error.

